### PR TITLE
Remove translation workbench from scratch org settings

### DIFF
--- a/force-app/main/default/reports/OmbudsmanCloudCare/Cases_Reported_to_Command_oIW.report-meta.xml
+++ b/force-app/main/default/reports/OmbudsmanCloudCare/Cases_Reported_to_Command_oIW.report-meta.xml
@@ -27,7 +27,6 @@
             <operator>equals</operator>
             <value>1</value>
         </criteriaItems>
-        <language>en_US</language>
     </filter>
     <format>Matrix</format>
     <groupingsAcross>

--- a/force-app/main/default/reports/OmbudsmanCloudCare/Cases_Still_on_Unknown_Sailor_VU4.report-meta.xml
+++ b/force-app/main/default/reports/OmbudsmanCloudCare/Cases_Still_on_Unknown_Sailor_VU4.report-meta.xml
@@ -26,7 +26,6 @@
             <operator>equals</operator>
             <value>Name Unknown (DO NOT EDIT)</value>
         </criteriaItems>
-        <language>en_US</language>
     </filter>
     <format>Summary</format>
     <groupingsDown>

--- a/force-app/main/default/reports/OmbudsmanCloudCare/Cases_with_Unknown_Sailor_1Xa.report-meta.xml
+++ b/force-app/main/default/reports/OmbudsmanCloudCare/Cases_with_Unknown_Sailor_1Xa.report-meta.xml
@@ -33,7 +33,6 @@
             <operator>equals</operator>
             <value>Name Unknown (DO NOT EDIT)</value>
         </criteriaItems>
-        <language>en_US</language>
     </filter>
     <format>Tabular</format>
     <name>Cases with Unknown Sailor</name>

--- a/force-app/main/default/reports/OmbudsmanCloudCare/Contacts_wo_Sailor_aRs.report-meta.xml
+++ b/force-app/main/default/reports/OmbudsmanCloudCare/Contacts_wo_Sailor_aRs.report-meta.xml
@@ -34,7 +34,6 @@
             <operator>notContain</operator>
             <value>DO NOT DELETE</value>
         </criteriaItems>
-        <language>en_US</language>
     </filter>
     <format>Summary</format>
     <groupingsDown>

--- a/force-app/main/default/reports/OmbudsmanCloudCare/Sailors_Missing_Rank_or_Email_8i0.report-meta.xml
+++ b/force-app/main/default/reports/OmbudsmanCloudCare/Sailors_Missing_Rank_or_Email_8i0.report-meta.xml
@@ -32,7 +32,6 @@
             <operator>notEqual</operator>
             <value>Unknown (DO NOT EDIT)</value>
         </criteriaItems>
-        <language>en_US</language>
     </filter>
     <format>Summary</format>
     <groupingsDown>

--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -28,9 +28,6 @@
         "forceRelogin": false
       }
     },
-    "languageSettings": {
-      "enableTranslationWorkbench": true
-    },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }

--- a/orgs/demo.json
+++ b/orgs/demo.json
@@ -28,9 +28,6 @@
         "forceRelogin": false
       }
     },
-    "languageSettings": {
-      "enableTranslationWorkbench": true
-    },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -28,9 +28,6 @@
         "forceRelogin": false
       }
     },
-    "languageSettings": {
-      "enableTranslationWorkbench": true
-    },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -28,9 +28,6 @@
         "forceRelogin": false
       }
     },
-    "languageSettings": {
-      "enableTranslationWorkbench": true
-    },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }

--- a/orgs/qa.json
+++ b/orgs/qa.json
@@ -28,9 +28,6 @@
         "forceRelogin": false
       }
     },
-    "languageSettings": {
-      "enableTranslationWorkbench": true
-    },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -28,9 +28,6 @@
         "forceRelogin": false
       }
     },
-    "languageSettings": {
-      "enableTranslationWorkbench": true
-    },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false
     }


### PR DESCRIPTION

# Critical Changes
Remove translation workbench from scratch org settings to remove need for language in reports.

# Changes

# Issues Closed
#49 