### PR TITLE
Remove Affiliation read access on Admin permisison set

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -145,7 +145,9 @@ tasks:
           - LogACall
           - NewEvent
           - NewCase
+          - SendEmail
           - Case.LogACall
+          - Case.SendEmail
         FlexiPage:
           - NPSP_Address_Record_Page
           - NPSP_Deliverable

--- a/force-app/main/default/permissionsets/Ombundsman_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Ombundsman_Admin.permissionset-meta.xml
@@ -103,15 +103,6 @@
         <object>Sailor__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
-    <objectPermissions>
-        <allowCreate>false</allowCreate>
-        <allowDelete>false</allowDelete>
-        <allowEdit>false</allowEdit>
-        <allowRead>true</allowRead>
-        <modifyAllRecords>false</modifyAllRecords>
-        <object>npe5__Affiliation__c</object>
-        <viewAllRecords>false</viewAllRecords>
-    </objectPermissions>
     <recordTypeVisibilities>
         <recordType>Contact.Family_Member</recordType>
         <visible>true</visible>


### PR DESCRIPTION

# Critical Changes
Due to issue with packaging on Master Detail relationships between standard and custom objects, removed from permission set.

# Changes

# Issues Closed
